### PR TITLE
Expose the worker object through thread interface

### DIFF
--- a/src/master/thread.ts
+++ b/src/master/thread.ts
@@ -1,5 +1,5 @@
 import { Observable } from "observable-fns"
-import { $errors, $events, $terminate } from "../symbols"
+import { $errors, $events, $terminate, $worker } from "../symbols"
 import { Thread as ThreadType, WorkerEvent } from "../types/master"
 
 function fail(message: string): never {
@@ -21,5 +21,9 @@ export const Thread = {
   /** Terminate a thread. Remember to terminate every thread when you are done using it. */
   terminate<ThreadT extends ThreadType>(thread: ThreadT) {
     return thread[$terminate]()
+  },
+  /** Returns the underlying worker object for the thread */
+  worker<ThreadT extends ThreadType>(thread: ThreadT) {
+    return thread[$worker]
   }
 }


### PR DESCRIPTION
- Will simplify managing the worker object 
- In codebase we will not required to keep track of worker and thread object separately 

In following reference we are keep track of worker and thread, though both are related. Keep one reference in code and access other with `Thread.worker` will simplify any logical error. 

https://github.com/ChainSafe/lodestar/blob/e3e9630eb101d93cb19361d62436849e9e45a588/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts#L50-L51
