### PR TITLE
fix: further increase max listeners of Worker

### DIFF
--- a/src/master/implementation.node.ts
+++ b/src/master/implementation.node.ts
@@ -127,7 +127,7 @@ function initWorkerThreadsWorker(): ImplementationExport {
       // Worker event emitter can have more than 10 listeners during normal operation
       // Increase max listeners to prevent MaxListenersExceededWarning
       // See https://github.com/ChainSafe/lodestar/issues/5552
-      this.setMaxListeners(100)
+      this.setMaxListeners(1000)
 
       this.mappedEventListeners = new WeakMap()
       allWorkers.push(this)


### PR DESCRIPTION
Follow up on https://github.com/ChainSafe/threads.js/pull/2 to further increase max listeners, seems like 100 is not sufficient